### PR TITLE
Retirando RoadSec

### DIFF
--- a/javascripts/data/events.json
+++ b/javascripts/data/events.json
@@ -37,18 +37,6 @@
             "link": "http://frontinaracaju.com.br/"
         },
         {
-            "titulo": "Roadsec Porto Alegre",
-            "dataInicio": "2016-10-29",
-            "dataFim": "2016-10-29",
-            "local": "Faculdade QI",
-            "endereco": "Rua Julio de Castilhos,435 - Centro - Porto Alegre/RS, CEP 90030-131",
-            "localizacao": {
-                "latitude": -30.041129,
-                "longitude": -51.2271
-            },
-            "link": "http://roadsec.com.br/portoalegre2016/"
-        },
-        {
             "titulo": "Roadsec São Paulo",
             "dataInicio": "2016-11-18",
             "dataFim": "2016-11-18",


### PR DESCRIPTION
O evento Roadsec São Paulo foi retirado do events.json pois o evento já aconteceu.